### PR TITLE
Change .codacy.json to .codacyrc on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sbt 'set version in Docker := "dev"' 'set name := "codacy-sonar-csharp"' docker:
 #### Run the docker
 
 ```
-docker run --user=docker --rm=true -v <PATH-TO-CODE>:/src -v <PATH-TO>/.codacy.json:/src/.codacy.json codacy/codacy-sonar-csharp:dev
+docker run --user=docker --rm=true -v <PATH-TO-CODE>:/src -v <PATH-TO>/.codacyrc:/.codacyrc codacy/codacy-sonar-csharp:dev
 ```
 > Make sure all the volumes mounted have the right permissions for user `docker`
 


### PR DESCRIPTION
The new structure uses `.codacyrc` instead of `.codacy.json`.

---
Reference: 
- https://github.com/codacy/codacy-engine-scala-seed/blob/master/src/main/scala/com/codacy/tools/scala/seed/DockerEnvironment.scala#L17