### PR TITLE
docs: update category converter

### DIFF
--- a/src/DocsGenerator/Description.cs
+++ b/src/DocsGenerator/Description.cs
@@ -2,7 +2,8 @@ using Newtonsoft.Json;
 
 namespace CodacyCSharp.DocsGenerator.Results
 {
-	public class Description {
+	public class Description
+	{
 		[JsonProperty (PropertyName = "patternId")]
 		public string PatternId { get; set; }
 

--- a/src/DocsGenerator/Helpers/CategoryHelper.cs
+++ b/src/DocsGenerator/Helpers/CategoryHelper.cs
@@ -1,14 +1,15 @@
-using CodacyCSharp.Seed.Patterns;
 using System.Xml.Linq;
+using CodacyCSharp.Seed.Patterns;
 
 namespace CodacyCSharp.DocsGenerator.Helpers
 {
-	public static class CategoryHelper {
-		public static Category ToCategory(XElement elem)
+	public static class CategoryHelper
+	{
+		public static Category ToCategory (XElement elem, Level lvl)
 		{
-			var tag = elem ?? new XElement("undefined");
+			var tag = elem.Element ("tag") ?? new XElement ("undefined");
 
-			switch(tag.Value)
+			switch (tag.Value)
 			{
 				case "api-design":
 				case "bad-practice":
@@ -20,24 +21,38 @@ namespace CodacyCSharp.DocsGenerator.Helpers
 				case "finding":
 				case "suspicious":
 				case "unpredictable":
+				case "deadlock":
 				case "pitfall":
+				case "localisation":
+				case "tests":
+				case "pinvoke":
 					return Category.ErrorProne;
 
 				case "cert":
 				case "cwe":
 				case "overflow":
+				case "owasp-a1":
+				case "owasp-a2":
+				case "owasp-a3":
+				case "owasp-a4":
+				case "owasp-a5":
 				case "owasp-a6":
-				case "sans-top25-porous":
+				case "owasp-a7":
+				case "owasp-a8":
+				case "owasp-a9":
+				case "owasp-a10":
 				case "security":
 				case "leak":
 				case "sans-top25-risky":
+				case "sans-top25-porous":
+				case "sans-top25-insecure":
 					return Category.Security;
 
 				case "multi-threading":
 				case "performance":
 				case "denial-of-service":
 					return Category.Performance;
-				
+
 				case "brain-overload":
 					return Category.Complexity;
 
@@ -48,8 +63,29 @@ namespace CodacyCSharp.DocsGenerator.Helpers
 				case "clumsy":
 				case "convention":
 				case "misra":
-				default:
+				case "style":
 					return Category.CodeStyle;
+
+				default:
+					var type = elem.Element ("type") ?? new XElement ("undefined");
+					switch (type.Value)
+					{
+						case "VULNERABILITY":
+							return Category.Security;
+						case "CODE_SMELL":
+							if (lvl == Level.Info)
+							{
+								return Category.CodeStyle;
+							}
+							else
+							{
+								return Category.ErrorProne;
+							}
+						case "BUG":
+							return Category.ErrorProne;
+						default:
+							return Category.CodeStyle;
+					}
 			}
 		}
 	}

--- a/src/DocsGenerator/Program.cs
+++ b/src/DocsGenerator/Program.cs
@@ -6,20 +6,24 @@ using System.Xml.Linq;
 using CodacyCSharp.Seed.Patterns;
 using Newtonsoft.Json;
 
-namespace CodacyCSharp.DocsGenerator {
+namespace CodacyCSharp.DocsGenerator
+{
 	using Helpers;
 
-	class Program {
+	static class Program
+	{
 		private const string docsFolder = "docs/";
 		private const string descriptionFolder = docsFolder + "description/";
 
-		static void Main (string[] args) {
+		static void Main (string[] args)
+		{
 			string sonarVersion = File.ReadAllText (".SONAR_VERSION").TrimEnd (Environment.NewLine.ToCharArray ());
 
 			Directory.CreateDirectory (docsFolder);
 			Directory.CreateDirectory (descriptionFolder);
 
-			CodacyPatterns patternsFile = new CodacyPatterns {
+			CodacyPatterns patternsFile = new CodacyPatterns
+			{
 				Name = "Sonar C#",
 					Version = sonarVersion,
 					Patterns = new List<Pattern> ()
@@ -28,21 +32,26 @@ namespace CodacyCSharp.DocsGenerator {
 			List<Results.Description> descriptions = new List<Results.Description> ();
 
 			var doc = XDocument.Load (@".res/sonar-csharp-rules.xml");
-			foreach (var rule in doc.Root.Elements ()) {
-				Pattern pattern = new Pattern {
+			foreach (var rule in doc.Root.Elements ())
+			{
+				var lvl = LevelHelper.ToLevel ((rule.Element ("severity") ?? new XElement ("undefined")).Value);
+				Pattern pattern = new Pattern
+				{
 					PatternId = rule.Element ("key").Value,
-						Level = LevelHelper.ToLevel ((rule.Element ("severity") ?? new XElement ("undefined")).Value),
-						Category = CategoryHelper.ToCategory (rule.Element ("tag")),
+						Level = lvl,
+						Category = CategoryHelper.ToCategory (rule, lvl),
 						Parameters = (from param in rule.Elements () where param.Name == "param"
-							select new Parameter {
+							select new Parameter
+							{
 								Name = param.Element ("key").Value,
 									Default = param.Element ("defaultValue").Value ?? ""
 							}).ToArray ()
 				};
 
-				Results.Description description = new Results.Description {
+				Results.Description description = new Results.Description
+				{
 					PatternId = pattern.PatternId,
-						Title = rule.Element ("name").Value
+					Title = rule.Element ("name").Value
 				};
 
 				patternsFile.Patterns.Add (pattern);
@@ -55,13 +64,15 @@ namespace CodacyCSharp.DocsGenerator {
 
 			string patternsJson = JsonConvert.SerializeObject (patternsFile,
 				Newtonsoft.Json.Formatting.Indented,
-				new JsonSerializerSettings {
+				new JsonSerializerSettings
+				{
 					NullValueHandling = NullValueHandling.Ignore
 				});
 
 			string descriptionJson = JsonConvert.SerializeObject (descriptions,
 				Newtonsoft.Json.Formatting.Indented,
-				new JsonSerializerSettings {
+				new JsonSerializerSettings
+				{
 					NullValueHandling = NullValueHandling.Ignore
 				});
 


### PR DESCRIPTION
Sonar C# was very outdated, so it has some new tags and I suggested to review it separately.

There is some tags like `c#6.0` which is not clear at all, so I used their `type` tag as a fallback to match Codacy categories.

**TIP**: To update the docs artifacts, you should do `make update-docs` (the artifacts are located on `.res/sonar-csharp-rules.xml`) or if you want to update the entire docs should do `make documentation` .
**NOTE**: Because the version `3.0.0` is a major and has breaking changes, this pull request should be merged before the release.
