### PR TITLE
fix: Filter used analysers by patterns CY-3607

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,43 +4,11 @@ orbs:
   codacy: codacy/base@2.3.1
   codacy_plugins_test: codacy/plugins-test@0.14.5
 
-jobs:
-  build:
-    docker:
-      #TODO: switch to docker image
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.2
-    working_directory: ~/workdir
-    steps:
-      - attach_workspace:
-          at: ~/workdir
-      - run:
-          name: Install packages
-          command: |
-            apt update
-            apt install -y apt-transport-https dirmngr gnupg ca-certificates
-            apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-            echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list
-            apt update
-            apt-get install -y mono-complete build-essential nuget unzip libxml2-utils
-      - run:
-          name: Compile
-          command: |
-            make
-            make documentation
-            make publish
-      - persist_to_workspace:
-          root: ~/workdir
-          paths:
-            - "*"
-
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - codacy/checkout_and_version
-      - build:
-          requires:
-            - codacy/checkout_and_version
       - codacy/shell:
           name: publish_local
           cmd: |
@@ -48,7 +16,7 @@ workflows:
             docker save --output docker-image.tar $CIRCLE_PROJECT_REPONAME:latest
           persist_to_workspace: true
           requires:
-            - build
+            - codacy/checkout_and_version
       - codacy_plugins_test/run:
           name: plugins_test
           run_multiple_tests: true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.vs/
+.res/
+packages/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
-FROM alpine:3.10
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS builder
 
-RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
-	apk add --no-cache --virtual=.build-dependencies ca-certificates && \
-	cert-sync /etc/ssl/certs/ca-certificates.crt && \
-	apk del .build-dependencies \
-	rm /tmp/* \
-	rm -rf /var/cache/apk/*
+RUN apt update && \
+    apt install -y apt-transport-https dirmngr gnupg ca-certificates && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb https://download.mono-project.com/repo/debian stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \
+    apt update && \
+    apt-get install -y mono-complete build-essential nuget unzip libxml2-utils
 
-COPY src/Analyzer/bin/Release/net461/publish/*.dll /opt/docker/bin/
-COPY src/Analyzer/bin/Release/net461/publish/*.exe /opt/docker/bin/
+COPY . /workdir
+WORKDIR /workdir
+
+RUN make
+RUN make publish
+
+FROM mono:6.10
+
+COPY --from=builder /workdir/src/Analyzer/bin/Release/net461/publish/*dll /opt/docker/bin/
+COPY --from=builder /workdir/src/Analyzer/bin/Release/net461/publish/*.exe /opt/docker/bin/
 COPY docs /docs/
 
-RUN adduser -u 2004 -D docker
+RUN adduser -u 2004 --disabled-password docker
 RUN chown -R docker:docker /docs
 
 ENTRYPOINT [ "mono", "/opt/docker/bin/Analyzer.exe" ]

--- a/docs/multiple-tests/filter-rules-not-included-patterns/patterns.xml
+++ b/docs/multiple-tests/filter-rules-not-included-patterns/patterns.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="SonarLint\.xml"/>
+    </module>
+</module>

--- a/docs/multiple-tests/filter-rules-not-included-patterns/results.xml
+++ b/docs/multiple-tests/filter-rules-not-included-patterns/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="S1134.cs">
+        <error source="S1134" line="5" message="Take the required action to fix the issue indicated by this 'FIXME' comment." severity="warning" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/filter-rules-not-included-patterns/src/S1134.cs
+++ b/docs/multiple-tests/filter-rules-not-included-patterns/src/S1134.cs
@@ -1,0 +1,11 @@
+public partial class Foobar {
+    private void DoSomething()
+    {
+        // TODO: This is a do stuff comment
+        // FIXME: This is a comment to fix stuff
+    }
+}
+
+class my_class {
+    private int foo = 20;
+}

--- a/docs/multiple-tests/filter-rules-not-included-patterns/src/SonarLint.xml
+++ b/docs/multiple-tests/filter-rules-not-included-patterns/src/SonarLint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AnalysisInput>
+    <Rules>
+        <Rule>
+            <Key>S1134</Key>
+        </Rule>
+    </Rules>
+</AnalysisInput>


### PR DESCRIPTION
Right now if one analyser supports multiple patterns we will run every pattern if one of them is enabled