### PR TITLE
doc: Use American English spelling "analyzing" on tool description DOCS-319

### DIFF
--- a/docs/tool-description.md
+++ b/docs/tool-description.md
@@ -1,1 +1,1 @@
-SonarC# is a static code analyser for C# language. It will allow you to produce stable and easily supported code by helping you to find and to correct bugs, vulnerabilities and smells in your code. [Learn more](https://github.com/SonarSource/sonar-csharp)
+SonarC# is a static code analyzer for C# language. It will allow you to produce stable and easily supported code by helping you to find and to correct bugs, vulnerabilities and smells in your code. [Learn more](https://github.com/SonarSource/sonar-csharp)


### PR DESCRIPTION
When making [this change](https://github.com/codacy/codacy-spa/pull/683) on codacy-spa I updated the description of the tools in the tests but forgot to update the actual tools themselves.

Related pull requests:

* https://github.com/codacy/codacy-prospector/pull/82
* https://github.com/codacy/codacy-sonar-visual-basic/pull/75