### PR TITLE
Add script to generate SonarLint.xml with our defaults enabled

### DIFF
--- a/docs/multiple-tests/exclude-rules-from-default/patterns.xml
+++ b/docs/multiple-tests/exclude-rules-from-default/patterns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="SonarLint\.xml"/>
+        <!--<property name="fileNamePattern" value="\.editorconfig"/>-->
+    </module>
+</module>

--- a/docs/multiple-tests/exclude-rules-from-default/results.xml
+++ b/docs/multiple-tests/exclude-rules-from-default/results.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="example.cs">
+        <!-- removed the following manually from the generated SonarLint.xml -->
+        <!-- <error source="S1451" line="1" message="Add or update the header of this file." severity="error" /> -->
+        <!-- <error source="S2933" line="5" message="Make 'bar' 'readonly'." severity="warning" /> -->
+        <!-- <error source="S3904" line="1" message="Provide an 'AssemblyVersion' attribute for assembly 'srcassembly.dll'." severity="error" /> -->
+
+        <error source="S3903" line="3" message="Move 'Foobar' into a named namespace." severity="warning" />
+        <error source="S3990" line="1" message="Provide a 'CLSCompliant' attribute for assembly 'srcassembly.dll'." severity="warning" />
+        <error source="S3992" line="1" message="Provide a 'ComVisible' attribute for assembly 'srcassembly.dll'." severity="warning" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/exclude-rules-from-default/results.xml
+++ b/docs/multiple-tests/exclude-rules-from-default/results.xml
@@ -2,12 +2,7 @@
 <checkstyle version="4.3">
     <file name="example.cs">
         <!-- removed the following manually from the generated SonarLint.xml -->
-        <!-- <error source="S1451" line="1" message="Add or update the header of this file." severity="error" /> -->
-        <!-- <error source="S2933" line="5" message="Make 'bar' 'readonly'." severity="warning" /> -->
-        <!-- <error source="S3904" line="1" message="Provide an 'AssemblyVersion' attribute for assembly 'srcassembly.dll'." severity="error" /> -->
-
-        <error source="S3903" line="3" message="Move 'Foobar' into a named namespace." severity="warning" />
-        <error source="S3990" line="1" message="Provide a 'CLSCompliant' attribute for assembly 'srcassembly.dll'." severity="warning" />
-        <error source="S3992" line="1" message="Provide a 'ComVisible' attribute for assembly 'srcassembly.dll'." severity="warning" />
+        <!-- which is enabled in our patterns as default and was trigering for the example.cs file. -->
+        <!--<error source="S2933" line="5" message="Make 'bar' 'readonly'." severity="warning" />-->
     </file>
 </checkstyle>

--- a/docs/multiple-tests/exclude-rules-from-default/src/SonarLint.xml
+++ b/docs/multiple-tests/exclude-rules-from-default/src/SonarLint.xml
@@ -2,907 +2,635 @@
 <AnalysisInput>
 <Rules>
 	<Rule>
-		<Key>S3966</Key>
+		<Key>S3655</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3900</Key>
+		<Key>S2583</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4158</Key>
+		<Key>S1944</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2589</Key>
+		<Key>S2259</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5773</Key>
+		<Key>S3442</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3329</Key>
+		<Key>S3244</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2053</Key>
+		<Key>S3236</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3923</Key>
+		<Key>S2330</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3415</Key>
+		<Key>S1121</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1200</Key>
+		<Key>S2306</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4060</Key>
+		<Key>S3168</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4583</Key>
+		<Key>S110</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1125</Key>
+		<Key>S1764</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1227</Key>
+		<Key>S1940</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3011</Key>
+		<Key>S3215</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3343</Key>
+		<Key>S3247</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4462</Key>
+		<Key>S2486</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3949</Key>
+		<Key>S2737</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4830</Key>
+		<Key>S3453</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3928</Key>
+		<Key>S3897</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S101</Key>
+		<Key>S1118</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S100</Key>
+		<Key>S125</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1694</Key>
+		<Key>S1210</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3776</Key>
+		<Key>S2688</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1155</Key>
+		<Key>S1862</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4004</Key>
+		<Key>S1871</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2971</Key>
+		<Key>S2760</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3909</Key>
+		<Key>S2228</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1134</Key>
+		<Key>S1699</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1135</Key>
+		<Key>S3869</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3240</Key>
+		<Key>S1854</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3972</Key>
+		<Key>S3172</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4260</Key>
+		<Key>S2931</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5034</Key>
+		<Key>S2930</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2479</Key>
+		<Key>S2997</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4426</Key>
+		<Key>S2952</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2115</Key>
+		<Key>S2953</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3346</Key>
+		<Key>S1215</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3906</Key>
+		<Key>S2551</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3903</Key>
+		<Key>S3874</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4524</Key>
+		<Key>S3875</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4002</Key>
+		<Key>S1186</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3902</Key>
+		<Key>S3261</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3885</Key>
+		<Key>S108</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1147</Key>
+		<Key>S1116</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3971</Key>
+		<Key>S2291</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1696</Key>
+		<Key>S1244</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2221</Key>
+		<Key>S2197</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3981</Key>
+		<Key>S3445</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2365</Key>
+		<Key>S3877</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4015</Key>
+		<Key>S3871</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3956</Key>
+		<Key>S2387</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4019</Key>
+		<Key>S2357</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4277</Key>
+		<Key>S1104</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3998</Key>
+		<Key>S3880</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4070</Key>
+		<Key>S2345</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3358</Key>
+		<Key>S3217</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4017</Key>
+		<Key>S127</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4143</Key>
+		<Key>S1994</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2183</Key>
+		<Key>S2934</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3060</Key>
+		<Key>S2955</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1048</Key>
+		<Key>S3246</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2114</Key>
+		<Key>S2326</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2701</Key>
+		<Key>S3249</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S106</Key>
+		<Key>S2328</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S881</Key>
+		<Key>S3397</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5542</Key>
+		<Key>S1313</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2344</Key>
+		<Key>S2692</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2342</Key>
+		<Key>S2190</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4016</Key>
+		<Key>S3444</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4022</Key>
+		<Key>S3220</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4035</Key>
+		<Key>S2184</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4220</Key>
+		<Key>S3052</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4027</Key>
+		<Key>S1185</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3984</Key>
+		<Key>S3218</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3431</Key>
+		<Key>S3427</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1067</Key>
+		<Key>S3600</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4226</Key>
+		<Key>S1006</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4225</Key>
+		<Key>S3262</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4025</Key>
+		<Key>S3450</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S104</Key>
+		<Key>S1172</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S113</Key>
+		<Key>S2681</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2346</Key>
+		<Key>S2386</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2252</Key>
+		<Key>S1163</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2251</Key>
+		<Key>S3459</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3376</Key>
+		<Key>S2360</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1541</Key>
+		<Key>S3466</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S134</Key>
+		<Key>S3451</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3464</Key>
+		<Key>S3447</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4018</Key>
+		<Key>S3169</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2219</Key>
+		<Key>S1206</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S907</Key>
+		<Key>S1226</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5332</Key>
+		<Key>S927</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4036</Key>
+		<Key>S3872</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4792</Key>
+		<Key>S2234</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4834</Key>
+		<Key>S3251</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3330</Key>
+		<Key>S1450</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2092</Key>
+		<Key>S2372</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4790</Key>
+		<Key>S2376</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4507</Key>
+		<Key>S3926</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4502</Key>
+		<Key>S2339</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5753</Key>
+		<Key>S2368</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2068</Key>
+		<Key>S3603</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2245</Key>
+		<Key>S3253</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4787</Key>
+		<Key>S3254</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5042</Key>
+		<Key>S1905</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5766</Key>
+		<Key>S3440</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2612</Key>
+		<Key>S3257</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5122</Key>
+		<Key>S3626</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5443</Key>
+		<Key>S2333</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4829</Key>
+		<Key>S3610</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5693</Key>
+		<Key>S3235</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4818</Key>
+		<Key>S3441</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4823</Key>
+		<Key>S3456</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2255</Key>
+		<Key>S1858</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2257</Key>
+		<Key>S1698</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4784</Key>
+		<Key>S2995</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4564</Key>
+		<Key>S2201</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S126</Key>
+		<Key>S2757</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1066</Key>
+		<Key>S1656</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3881</Key>
+		<Key>S3449</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3925</Key>
+		<Key>S2437</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3927</Key>
+		<Key>S2743</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3973</Key>
+		<Key>S3263</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3963</Key>
+		<Key>S2223</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5547</Key>
+		<Key>S3010</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5445</Key>
+		<Key>S2696</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4039</Key>
+		<Key>S2156</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4023</Key>
+		<Key>S2674</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1309</Key>
+		<Key>S1643</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S5659</Key>
+		<Key>S2275</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4433</Key>
+		<Key>S3457</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S103</Key>
+		<Key>S1449</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4055</Key>
+		<Key>S3876</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S818</Key>
+		<Key>S3234</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3267</Key>
+		<Key>S3458</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S109</Key>
+		<Key>S1301</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3990</Key>
+		<Key>S3532</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3992</Key>
+		<Key>S131</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4026</Key>
+		<Key>S3216</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4210</Key>
+		<Key>S3889</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3604</Key>
+		<Key>S3005</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4211</Key>
+		<Key>S2996</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4136</Key>
+		<Key>S112</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4261</Key>
+		<Key>S2225</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3400</Key>
+		<Key>S3443</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4144</Key>
+		<Key>S2761</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S138</Key>
+		<Key>S3264</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3242</Key>
+		<Key>S3241</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1659</Key>
+		<Key>S121</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3887</Key>
+		<Key>S2178</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S2302</Key>
+		<Key>S3237</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4200</Key>
+		<Key>S2123</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S1199</Key>
+		<Key>S3898</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4581</Key>
+		<Key>S1117</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S4586</Key>
+		<Key>S1481</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3260</Key>
+		<Key>S3597</Key>
 	</Rule>
 
 	<Rule>
-		<Key>S3265</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4040</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3937</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1848</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1123</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4069</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4050</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4457</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4456</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4428</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4214</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4000</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3967</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4275</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4049</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4059</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2292</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1939</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4201</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1110</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3993</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1168</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1109</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3884</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4212</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4057</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4159</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S122</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4056</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4058</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2857</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1192</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4635</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1151</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1821</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S105</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2187</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2699</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3433</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1607</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3366</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2436</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1479</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S107</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3717</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2327</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3059</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4041</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4052</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3353</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1751</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1128</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4487</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1075</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3962</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3908</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4047</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2148</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4061</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3256</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3994</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3995</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3996</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S3997</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4005</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S1264</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2290</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S4423</Key>
-	</Rule>
-
-	<Rule>
-		<Key>S2755</Key>
+		<Key>S3598</Key>
 	</Rule>
 
 </Rules>

--- a/docs/multiple-tests/exclude-rules-from-default/src/SonarLint.xml
+++ b/docs/multiple-tests/exclude-rules-from-default/src/SonarLint.xml
@@ -1,0 +1,909 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnalysisInput>
+<Rules>
+	<Rule>
+		<Key>S3966</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3900</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4158</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2589</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5773</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3329</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2053</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3923</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3415</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1200</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4060</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4583</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1125</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1227</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3011</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3343</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4462</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3949</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4830</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3928</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S101</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S100</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1694</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3776</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1155</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4004</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2971</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3909</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1134</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1135</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3240</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3972</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4260</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5034</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2479</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4426</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2115</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3346</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3906</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3903</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4524</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4002</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3902</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3885</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1147</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3971</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1696</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2221</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3981</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2365</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4015</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3956</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4019</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4277</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3998</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4070</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3358</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4017</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4143</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2183</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3060</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1048</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2114</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2701</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S106</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S881</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5542</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2344</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2342</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4016</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4022</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4035</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4220</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4027</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3984</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3431</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1067</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4226</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4225</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4025</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S104</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S113</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2346</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2252</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2251</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3376</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1541</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S134</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3464</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4018</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2219</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S907</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5332</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4036</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4792</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4834</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3330</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2092</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4790</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4507</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4502</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5753</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2068</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2245</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4787</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5042</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5766</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2612</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5122</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5443</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4829</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5693</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4818</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4823</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2255</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2257</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4784</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4564</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S126</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1066</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3881</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3925</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3927</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3973</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3963</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5547</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5445</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4039</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4023</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1309</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S5659</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4433</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S103</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4055</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S818</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3267</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S109</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3990</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3992</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4026</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4210</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3604</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4211</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4136</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4261</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3400</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4144</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S138</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3242</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1659</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3887</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2302</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4200</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1199</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4581</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4586</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3260</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3265</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4040</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3937</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1848</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1123</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4069</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4050</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4457</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4456</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4428</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4214</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4000</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3967</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4275</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4049</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4059</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2292</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1939</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4201</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1110</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3993</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1168</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1109</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3884</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4212</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4057</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4159</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S122</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4056</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4058</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2857</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1192</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4635</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1151</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1821</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S105</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2187</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2699</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3433</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1607</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3366</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2436</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1479</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S107</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3717</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2327</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3059</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4041</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4052</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3353</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1751</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1128</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4487</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1075</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3962</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3908</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4047</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2148</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4061</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3256</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3994</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3995</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3996</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S3997</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4005</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S1264</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2290</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S4423</Key>
+	</Rule>
+
+	<Rule>
+		<Key>S2755</Key>
+	</Rule>
+
+</Rules>
+</AnalysisInput>

--- a/docs/multiple-tests/exclude-rules-from-default/src/example.cs
+++ b/docs/multiple-tests/exclude-rules-from-default/src/example.cs
@@ -1,0 +1,6 @@
+//#Patterns: S103 : { "maximumLineLength": 24 }
+
+public class Foobar {
+    //#Warn: S103
+    private int bar = 10;
+}

--- a/generate-sonarlint-file-from-default-codacy-rules.sh
+++ b/generate-sonarlint-file-from-default-codacy-rules.sh
@@ -1,0 +1,27 @@
+#!/bin/env bash
+
+container_id=$(docker create codacy-csharp:latest)
+codacy_rules_file=/tmp/codacy-rules.json
+
+# get all the rules defined for the tool from inside the docker container
+docker cp $container_id:/docs/patterns.json $codacy_rules_file
+docker rm $container_id
+
+# obtain all ids of the rules we have enabled by default
+rules_ids=$(cat $codacy_rules_file | jq -r '.patterns[] | select (.enabled == false) | .patternId')
+
+cat << EOF > SonarLint.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<AnalysisInput>
+<Rules>
+EOF
+
+for rule_id in $rules_ids
+do
+	echo -e "\t<Rule>\n\t\t<Key>$rule_id</Key>\n\t</Rule>\n" >> SonarLint.xml
+done
+
+cat << EOF >> SonarLint.xml
+</Rules>
+</AnalysisInput>
+EOF

--- a/generate-sonarlint-file-from-default-codacy-rules.sh
+++ b/generate-sonarlint-file-from-default-codacy-rules.sh
@@ -8,7 +8,7 @@ docker cp $container_id:/docs/patterns.json $codacy_rules_file
 docker rm $container_id
 
 # obtain all ids of the rules we have enabled by default
-rules_ids=$(cat $codacy_rules_file | jq -r '.patterns[] | select (.enabled == false) | .patternId')
+rules_ids=$(cat $codacy_rules_file | jq -r '.patterns[] | select (.enabled == true) | .patternId')
 
 cat << EOF > SonarLint.xml
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The script is added for documentation / other needs that may come, since we have no way on our system to disable a single rule when using a SonaLint.xml file besides telling the users to get a SonarLint.xml with all the rules explicitly written and then removing the specific ones they don't want enabled.

The script basically goes to the tool docker image, gets the patterns that are enabled and generates the xml file.

Added a test that uses that file with some manually removed rules to show that it actually works.

relates to ticket [CY-5895](https://codacy.atlassian.net/browse/CY-5895)