### PR TITLE
bump: Use a more recent version of the upstream lirbary & cleanups

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,26 +46,6 @@
 			}
 		},
 		{
-			"label": "CodacyCSharp.Seed",
-			"type": "process",
-			"command": "make",
-			"args": [
-				"build-seed"
-			],
-			"options": {
-				"cwd": "${workspaceFolder}/src/Seed"
-			},
-			"problemMatcher": [],
-			"presentation": {
-				"echo": true,
-				"reveal": "silent",
-				"focus": false,
-				"panel": "shared",
-				"showReuseMessage": true,
-				"clear": false
-			}
-		},
-		{
 			"label": "CodacyCSharp.DocsGenerator",
 			"type": "process",
 			"command": "make",

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-export FrameworkPathOverride=$(shell dirname $(shell which mono))/../lib/mono/4.5/
 SONAR_VERSION=$(shell xmllint --xpath 'string(/Project/ItemGroup/PackageReference[@Include="SonarAnalyzer.CSharp"]/@Version)' src/Analyzer/Analyzer.csproj | tr -d '\n')
+
 BUILD_CMD=dotnet build --no-restore /property:GenerateFullPaths=true
 
-LIBRARIES_FOLDER=.lib
-PACKAGES_FOLDER=.packages
 RESOURCE_FOLDER=.res
 
 all: configure build
@@ -14,13 +12,8 @@ configure:
 build-all:
 	$(BUILD_CMD)
 
-build: src/Analyzer
-
 build:
-	$(BUILD_CMD) $^
-
-build-seed:
-	$(BUILD_CMD) src/Seed
+	$(BUILD_CMD) src/Analyzer
 
 build-docs:
 	$(BUILD_CMD) src/DocsGenerator

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ This is the docker engine we use at Codacy to run [SonarC#](https://github.com/S
 You can also create a docker to integrate the tool and language of your choice!
 Check the **Docs** section for more information.
 
+## Local Development
+
+**Requirements**:
+ - unzip, xmllint
+ - mono - implementation of .NET platform including compiler and runtime
+ - dotnet-sdk (on Archlinux also installs dotnet-runtim & dotnet-host & dotnet-targeting-pack) - the .NET Core SDK
+
+Compile the code with `make build-all`, just the main code with `make build`, or just the docs generator with `make build-docs`.
+See other useful targets inside the `Makefile`.
+
+
 ## Usage
 
 ### Publish the docker

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ Check the **Docs** section for more information.
 ## Local Development
 
 **Requirements**:
- - unzip, xmllint
- - mono - implementation of .NET platform including compiler and runtime
- - dotnet-sdk (on Archlinux also installs dotnet-runtim & dotnet-host & dotnet-targeting-pack) - the .NET Core SDK
+  - unzip, xmllint
+  - mono - implementation of .NET platform including compiler and runtime
+  - dotnet-sdk (on Archlinux also installs dotnet-runtim & dotnet-host & dotnet-targeting-pack) - the .NET Core SDK
 
 Compile the code with `make build-all`, just the main code with `make build`, or just the docs generator with `make build-docs`.
 See other useful targets inside the `Makefile`.
-
 
 ## Usage
 

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
         <PackageReference Include="SQLitePCLRaw.core" Version="2.0.7" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" GeneratePathProperty="true" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503" GeneratePathProperty="true" />
         <PackageReference Include="Codacy.Engine.Seed" Version="2.1.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -5,9 +5,6 @@
         <RootNamespace>CodacyCSharp.Analyzer</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-mono" Version="0.5.6" />
-    </ItemGroup>
-    <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
         <PackageReference Include="SQLitePCLRaw.core" Version="2.0.7" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="8.30.0.37606" GeneratePathProperty="true" />

--- a/src/Analyzer/CodeAnalyzer.cs
+++ b/src/Analyzer/CodeAnalyzer.cs
@@ -92,6 +92,7 @@ namespace CodacyCSharp.Analyzer
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>
@@ -102,15 +103,10 @@ namespace CodacyCSharp.Analyzer
             Dispose(false);
         }
 
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                GC.SuppressFinalize(this);
-            }
-
             // delete created temporary directory
-            if(tmpSonarLintFolder != null)
+            if (tmpSonarLintFolder != null)
             {
                 Directory.Delete(tmpSonarLintFolder, true);
             }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+  </ItemGroup>
+</Project>
+
+

--- a/src/DocsGenerator/DocsGenerator.csproj
+++ b/src/DocsGenerator/DocsGenerator.csproj
@@ -5,9 +5,6 @@
         <RootNamespace>CodacyCSharp.DocsGenerator</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <DotNetCliToolReference Include="dotnet-mono" Version="0.5.6" />
-    </ItemGroup>
-    <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="ReverseMarkdown" Version="3.23.0" />
     </ItemGroup>

--- a/src/DocsGenerator/Helpers/TTFHelper.cs
+++ b/src/DocsGenerator/Helpers/TTFHelper.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CodacyCSharp.DocsGenerator.Helpers
 {
+    [SuppressMessage("", "S101")]
     public static class TTFHelper
     {
         public static long ToCodacyTimeToFix(string sonarTimeToFix)


### PR DESCRIPTION
We were using the version `8.30.0.37606` (released ~6 months ago). Managed to update up to version `8.33.0.40503` (released ~4 months ago). Available versions - https://www.nuget.org/packages/SonarAnalyzer.CSharp/#versions-tab . 

Futher update needs refactoring of the code because of changes required in the RuleFinder derived from this upstream PR - https://github.com/SonarSource/sonar-dotnet/pull/5199 . 

Clean up makefile, updated readme with up to date info on requirements and some other things that could be improved.

