### PR TITLE
bump: Use latest base image and orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.3.1
-  codacy_plugins_test: codacy/plugins-test@0.15.4
+  codacy: codacy/base@9.3.5
+  codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.403 AS builder
 
 COPY . /workdir
 WORKDIR /workdir
@@ -8,7 +8,7 @@ RUN make
 RUN make publish
 RUN make documentation
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0.11
 
 COPY --from=builder /workdir/src/Analyzer/bin/Release/net6/publish/ /opt/docker/bin/
 COPY --from=builder /workdir/docs /docs/


### PR DESCRIPTION
Bumps images to fix vulnerabilities. Fixes issues with ci/cd pipelines