### PR TITLE
fix: Add missing context to tag_version ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,6 @@ workflows:
             - plugins_test
       - codacy/tag_version:
           name: tag_version
+          context: CodacyAWS
           requires:
             - codacy/publish_docker


### PR DESCRIPTION
Fixes the issue with repo tagging not working, which is making ci pipelines fail.