### PR TITLE
fix: update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.403 AS builder
+ARG DOTNET_VERSION=6.0-alpine3.17
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION AS builder
 
 COPY . /workdir
 WORKDIR /workdir
 
-RUN apt update && apt install -y make unzip libxml2-utils
-RUN make
-RUN make publish
-RUN make documentation
+RUN apk add --no-cache make unzip libxml2-utils &&\
+    make &&\
+    make publish &&\
+    make documentation
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0.11
+FROM mcr.microsoft.com/dotnet/runtime:$DOTNET_VERSION
 
 COPY --from=builder /workdir/src/Analyzer/bin/Release/net6/publish/ /opt/docker/bin/
 COPY --from=builder /workdir/docs /docs/
 
-RUN adduser -u 2004 --disabled-password docker
-RUN chown -R docker:docker /docs
+RUN adduser -u 2004 -D docker &&\
+    chown -R docker:docker /docs
 
 ENTRYPOINT [ "dotnet", "/opt/docker/bin/Analyzer.dll" ]


### PR DESCRIPTION
Use alpine base image because it is more recent and has no vulnerabilities and cleanup commands.