### PR TITLE
Updates SonarCsharp and bumps small things (IO-397)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@9.3.5
+  codacy: codacy/base@10.1.1
   codacy_plugins_test: codacy/plugins-test@1.1.1
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+## BUILD IMAGE
 ARG DOTNET_VERSION=6.0-alpine3.17
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION AS builder
 
@@ -9,12 +10,17 @@ RUN apk add --no-cache make unzip libxml2-utils &&\
     make publish &&\
     make documentation
 
+## RUNTIME IMAGE
 FROM mcr.microsoft.com/dotnet/runtime:$DOTNET_VERSION
 
 COPY --from=builder /workdir/src/Analyzer/bin/Release/net6/publish/ /opt/docker/bin/
 COPY --from=builder /workdir/docs /docs/
 
+# Create NON-ROOT user
 RUN adduser -u 2004 -D docker &&\
     chown -R docker:docker /docs
+
+# From now on, run as NON-ROOT user
+USER docker
 
 ENTRYPOINT [ "dotnet", "/opt/docker/bin/Analyzer.dll" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## BUILD IMAGE
-ARG DOTNET_VERSION=6.0-alpine3.17
+ARG DOTNET_VERSION=7.0-alpine3.17
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_VERSION AS builder
 
 COPY . /workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache make unzip libxml2-utils &&\
     make publish &&\
     make documentation
 
+
 ## RUNTIME IMAGE
 FROM mcr.microsoft.com/dotnet/runtime:$DOTNET_VERSION-$DOTNET_BASE_OS
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SONAR_VERSION=$(shell xmllint --xpath 'string(/Project/ItemGroup/PackageReference[@Include="SonarAnalyzer.CSharp"]/@Version)' src/Analyzer/Analyzer.csproj | tr -d '\n')
 
 BUILD_CMD=dotnet build --no-restore /property:GenerateFullPaths=true
-
 RESOURCE_FOLDER=.res
 
 all: configure build
@@ -35,7 +34,7 @@ documentation:
 	rm .SONAR_VERSION
 
 publish:
-	dotnet publish -c Release
+	dotnet publish -c Release -f net6
 
 clean:
-	rm -rf .lib/ .packages/ .res/ packages
+	rm -rf .res packages

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ documentation:
 	dotnet "src/DocsGenerator/bin/Debug/net6/DocsGenerator.dll"
 	rm .SONAR_VERSION
 
+run:
+	dotnet run --project src/Analyzer -f net6
+
 publish:
 	dotnet publish -c Release -f net6
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ documentation:
 	rm .SONAR_VERSION
 
 publish:
-	dotnet publish -c Release -f net6
+	dotnet publish -c Release
 
 clean:
 	rm -rf .lib/ .packages/ .res/ packages

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ publish:
 	dotnet publish -c Release -f net6
 
 clean:
-	rm -rf .lib/ .packages/ .res/
+	rm -rf .lib/ .packages/ .res/ packages

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Check the **Docs** section for more information.
   - xmllint
     * on ubuntu: `apt-get install libxml2-utils`
     * on alpine: `apk add libxml2-utils`
-  - dotnet-sdk - "The .NET Core SDK"
+  - dotnet-sdk-6.0 - "The .NET Core SDK"
     * on archlinux: the above package also installs `dotnet-runtime`, `dotnet-host` and `dotnet-targeting-pack`) - the .NET Core SDK
 
 ### IDE

--- a/README.md
+++ b/README.md
@@ -11,54 +11,58 @@ Check the **Docs** section for more information.
 ## Local Development
 
 **Requirements**:
-  - unzip, xmllint
-  - dotnet-sdk (on Archlinux also installs dotnet-runtim & dotnet-host & dotnet-targeting-pack) - the .NET Core SDK
+  - unzip 
+  - xmllint
+    * on ubuntu: `apt-get install libxml2-utils`
+    * on alpine: `apk add libxml2-utils`
+  - dotnet-sdk - "The .NET Core SDK"
+    * on archlinux: the above package also installs `dotnet-runtime`, `dotnet-host` and `dotnet-targeting-pack`) - the .NET Core SDK
 
-Compile the code with `make build-all`, just the main code with `make build`, or just the docs generator with `make build-docs`.
+### IDE
+
+This seems to be more or less working in vscode, install the 
+"C# for Visual Studio Code (powered by OmniSharp)" extension 
+and before opening the project in it do `make configure`.
+
+### Commands
+
+  - `make configure` - runs `dotnet restore` which downloads all the required libraries for the projects to work.
+  - `make build` - compiles the *Analyzer* project.
+  - `make build-docs` - compiles the *DocsGenerator* project.
+  - `make build-all` - compiles both the *Analyzer* and *DocsGenerator* projects.
+  - `make documentation` - downloads upstream rules for the *sonar version* we defined in `Analyzer.csproj`,
+    extracts the rules for that version and runs the *DocsGenerator* application.
+
 See other useful targets inside the `Makefile`.
 
 ## Usage
 
-### Publish the docker
+### Publish the docker image locally
 
 ```bash
-docker build -t codacy-sonar-csharp .
+docker build -t codacy-sonar-csharp:local .
 ```
 
-### Run the docker
+### Run the docker locally
 
 ```bash
-docker run --user=docker --rm=true -v <PATH-TO-CODE>:/src -v <PATH-TO>/.codacyrc:/.codacyrc codacy-sonar-csharp
+docker run --user=docker --rm -v <PATH-TO-CODE>:/src:ro -v <PATH-TO>/.codacyrc:/.codacyrc:ro codacy-sonar-csharp:local
+```
+
+### Enter inside the docker image
+
+```bash
+docker run --user=docker --rm -v <PATH-TO-CODE>:/src:ro -v <PATH-TO>/.codacyrc:/.codacyrc:ro -it --entrypoint /bin/sh codacy-sonar-csharp:local
 ```
 
 > Make sure all the volumes mounted have the right permissions for user `docker`
-
-### Generate Docs
-
-**Requirements:**
-
--   `xmllint` utility installed on your system:
-
-    -   On ubuntu:
-
-            apt-get install libxml2-utils
-
-    -   On alpine
-
-            apk add libxml2-utils
-
-**Generate:**
-
-```sh
-make documentation
-```
 
 ## Tool configuration file
 
 Currently, to use your own configuration file, you must add a SonarLint.xml xml file with an AnalysisInput structure inside.
 
 Example:
-
+```
     <?xml version="1.0" encoding="UTF-8"?>
     <AnalysisInput>
       <Rules>
@@ -73,6 +77,7 @@ Example:
         </Rule>
       </Rules>
     </AnalysisInput>
+```
 
 ## Docs
 

--- a/docs/description/S2148.md
+++ b/docs/description/S2148.md
@@ -2,14 +2,11 @@ Beginning with C# 7, it is possible to add underscores ('\_') to numeric literal
  
 The number of digits to the left of a decimal point needed to trigger this rule varies by base.
 
-    | Base | Minimum digits |
+| Base | Minimum digits |
 | --- | --- |
-
-    | binary | 9 |
-
-    | decimal | 6 |
-
-    | hexadecimal | 9 |
+| binary | 9 |
+| decimal | 6 |
+| hexadecimal | 9 |
 
 It is only the presence of underscores, not their spacing that is scrutinized by this rule.
  

--- a/docs/description/S3962.md
+++ b/docs/description/S3962.md
@@ -4,36 +4,22 @@ This rule raises an issue when a `static readonly` field is initialized with a v
  
 As specified by Microsoft, the list of types that can have a constant value are:
 
-    | C# type | .Net Fwk type |
+| C# type | .Net Fwk type |
 | --- | --- |
-
-    | bool | System.Boolean |
-
-    | byte | System.Byte |
-
-    | sbyte | System.SByte |
-
-    | char | System.Char |
-
-    | decimal | System.Decimal |
-
-    | double | System.Double |
-
-    | float | System.Single |
-
-    | int | System.Int32 |
-
-    | uint | System.UInt32 |
-
-    | long | System.Int64 |
-
-    | ulong | System.UInt64 |
-
-    | short | System.Int16 |
-
-    | ushort | System.UInt16 |
-
-    | string | System.String |
+| bool | System.Boolean |
+| byte | System.Byte |
+| sbyte | System.SByte |
+| char | System.Char |
+| decimal | System.Decimal |
+| double | System.Double |
+| float | System.Single |
+| int | System.Int32 |
+| uint | System.UInt32 |
+| long | System.Int64 |
+| ulong | System.UInt64 |
+| short | System.Int16 |
+| ushort | System.UInt16 |
+| string | System.String |
 
 ## Noncompliant Code Example
 

--- a/docs/description/S4069.md
+++ b/docs/description/S4069.md
@@ -1,43 +1,25 @@
 Operator overloading is convenient but unfortunately not portable across languages. To be able to access the same functionality from another language you need to provide an alternate named method following the convention:
 
-    | Operator | Method Name |
+| Operator | Method Name |
 | --- | --- |
-
-    | `+` (binary) | Add |
-
-    | `&` | BitwiseAnd |
-
-    | `|` | BitwiseOr |
-
-    | `/` | Divide |
-
-    | `==` | Equals |
-
-    | `^` | Xor |
-
-    | `>` | Compare |
-
-    | `>=` | Compare |
-
-    | `!=` | Equals |
-
-    | `<` | Compare |
-
-    | `<=` | Compare |
-
-    | `!` | LogicalNot |
-
-    | `%` | Mod |
-
-    | `*` (binary) | Multiply |
-
-    | `~` | OnesComplement |
-
-    | `-` (binary) | Subtract |
-
-    | `-` (unary) | Negate |
-
-    | `+` (unary) | Plus |
+| `+` (binary) | Add |
+| `&` | BitwiseAnd |
+| `|` | BitwiseOr |
+| `/` | Divide |
+| `==` | Equals |
+| `^` | Xor |
+| `>` | Compare |
+| `>=` | Compare |
+| `!=` | Equals |
+| `<` | Compare |
+| `<=` | Compare |
+| `!` | LogicalNot |
+| `%` | Mod |
+| `*` (binary) | Multiply |
+| `~` | OnesComplement |
+| `-` (binary) | Subtract |
+| `-` (unary) | Negate |
+| `+` (unary) | Plus |
 
 This rule raises an issue when there is an operator overload without the expected named alternative method.
  

--- a/docs/description/S4462.md
+++ b/docs/description/S4462.md
@@ -4,16 +4,12 @@ According to the MSDN documentation:
 
 > The root cause of this deadlock is due to the way `await` handles contexts. By default, when an incomplete `Task` is   awaited, the current “context” is captured and used to resume the method when the `Task` completes. This “context” is the current   `SynchronizationContext` unless it’s null, in which case it’s the current `TaskScheduler`. GUI and ASP.NET applications have a   `SynchronizationContext` that permits only one chunk of code to run at a time. When the `await` completes, it attempts to   execute the remainder of the `async` method within the captured context. But that context already has a thread in it, which is   (synchronously) waiting for the `async` method to complete. They’re each waiting for the other, causing a deadlock.
 
-    | To Do This … | Instead of This … | Use This |
+| To Do This … | Instead of This … | Use This |
 | --- | --- | --- |
-
-    | Retrieve the result of a background task | `Task.Wait`, `Task.Result` or `Task.GetAwaiter.GetResult` | `await` |
-
-    | Wait for any task to complete | `Task.WaitAny` | `await Task.WhenAny` |
-
-    | Retrieve the results of multiple tasks | `Task.WaitAll` | `await Task.WhenAll` |
-
-    | Wait a period of time | `Thread.Sleep` | `await Task.Delay` |
+| Retrieve the result of a background task | `Task.Wait`, `Task.Result` or `Task.GetAwaiter.GetResult` | `await` |
+| Wait for any task to complete | `Task.WaitAny` | `await Task.WhenAny` |
+| Retrieve the results of multiple tasks | `Task.WaitAll` | `await Task.WhenAll` |
+| Wait a period of time | `Thread.Sleep` | `await Task.Delay` |
 
 ## Noncompliant Code Example
 

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -1244,11 +1244,6 @@
     "timeToFix": 10
   },
   {
-    "patternId": "S4581",
-    "title": "\"new Guid()\" should not be used",
-    "timeToFix": 5
-  },
-  {
     "patternId": "S1163",
     "title": "Exceptions should not be thrown in finally blocks",
     "timeToFix": 30
@@ -1381,6 +1376,11 @@
   {
     "patternId": "S4000",
     "title": "Pointers to unmanaged memory should not be visible",
+    "timeToFix": 5
+  },
+  {
+    "patternId": "S4581",
+    "title": "\"new Guid()\" should not be used",
     "timeToFix": 5
   },
   {

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarscharp",
-  "version": "8.39",
+  "version": "8.40",
   "patterns": [
     {
       "patternId": "S3442",
@@ -1509,12 +1509,6 @@
       "enabled": false
     },
     {
-      "patternId": "S4581",
-      "category": "ErrorProne",
-      "level": "Warning",
-      "enabled": false
-    },
-    {
       "patternId": "S1163",
       "category": "ErrorProne",
       "level": "Error",
@@ -1674,6 +1668,12 @@
       "patternId": "S4000",
       "category": "ErrorProne",
       "level": "Error",
+      "enabled": false
+    },
+    {
+      "patternId": "S4581",
+      "category": "ErrorProne",
+      "level": "Warning",
       "enabled": false
     },
     {

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6</TargetFrameworks>
+        <TargetFramework>net7</TargetFramework>
         <RootNamespace>CodacyCSharp.Analyzer</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
         <PackageReference Include="SQLitePCLRaw.core" Version="2.1.4" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.39.0.47922" GeneratePathProperty="true" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530" GeneratePathProperty="true" />
         <PackageReference Include="Codacy.Engine.Seed" Version="2.1.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFrameworks>net6;net7</TargetFrameworks>
         <RootNamespace>CodacyCSharp.Analyzer</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6;net7</TargetFrameworks>
+        <TargetFrameworks>net6</TargetFrameworks>
         <RootNamespace>CodacyCSharp.Analyzer</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Analyzer/Analyzer.csproj
+++ b/src/Analyzer/Analyzer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <RootNamespace>CodacyCSharp.Analyzer</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Analyzer/Utilities/RuleFinder.cs
+++ b/src/Analyzer/Utilities/RuleFinder.cs
@@ -6,7 +6,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using SonarAnalyzer.Common;
 using SonarAnalyzer.Rules;
-using SonarAnalyzer.Rules.Common;
 using SonarAnalyzer.Rules.CSharp;
 
 namespace CodacyCSharp.Analyzer.Utilities

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 </Project>
 

--- a/src/DocsGenerator/DocsGenerator.csproj
+++ b/src/DocsGenerator/DocsGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6;net7</TargetFrameworks>
+        <TargetFrameworks>net6</TargetFrameworks>
         <RootNamespace>CodacyCSharp.DocsGenerator</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/DocsGenerator/DocsGenerator.csproj
+++ b/src/DocsGenerator/DocsGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFrameworks>net6;net7</TargetFrameworks>
         <RootNamespace>CodacyCSharp.DocsGenerator</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/DocsGenerator/DocsGenerator.csproj
+++ b/src/DocsGenerator/DocsGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7</TargetFramework>
+        <TargetFramework>net6</TargetFramework>
         <RootNamespace>CodacyCSharp.DocsGenerator</RootNamespace>
     </PropertyGroup>
     <ItemGroup>

--- a/src/DocsGenerator/DocsGenerator.csproj
+++ b/src/DocsGenerator/DocsGenerator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
         <RootNamespace>CodacyCSharp.DocsGenerator</RootNamespace>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
**Following updates:**
 * circle ci orbs to latests;
 * docker to sync with `codacy-metrics-sonar-csharp` too;
 * tool running in docker is running as docker user, no longer root;
 * Bumped `SonarAnalyzer.CSharp` only by one version, to `8.40`. Any further bumps need deep commitment from someone that actually knows CSharp since the library code changed non trivially;
 * ran make documentation to sync patterns description in git;
 * cleaned up readme to have a little bit more exhaustive information;


**Notes:**
 * tried to build with net7 also and things seem to work at least on my machine where I installed both sdks. But can't have the description have the net7 in the target frameworks without also bumping the docker sdk to latest, so left all as default net6 which is lts release.

closes #160 